### PR TITLE
formatters has renamed the `matrix_print_form` function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tables
 Title: Formula-Driven Table Generation
-Version: 0.9.23
+Version: 0.9.24
 Author: Duncan Murdoch
 Description: Computes and displays complex tables of summary statistics.
   Output may be in LaTeX, HTML, plain text, or an R

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tables 0.9.23
+# tables 0.9.24
 
 - `PlusMinus()` and `Paste()` didn't handle formatting properly 
 when multiple columns were involved (issue #13).
@@ -7,6 +7,7 @@ to file properly.  (Reported by Reinhard Kerschner and F. Hortner.)
 - In some cases `All()` would give an error (issue #17).
 - `toTinytable()` function has been added to work with the
 `tinytable` package.
+- Minor update due to changes to the `formatters` package.
 
 # tables 0.9.17
 

--- a/R/tables_mform.R
+++ b/R/tables_mform.R
@@ -49,7 +49,18 @@ matrix_form.tabular <- function(df) {
   formats <- matrix("xx", rows, cols)
   row_info <- formatters::basic_pagdf(1:(rows - nrow(header)))
   nrow_header <- nrow(header)
-  formatters::matrix_print_form(strings = strings,
+  
+  # formatters has renamed the matrix_print_form function to
+  # MatrixPrintForm
+  MatrixPrintForm <- 
+    if (exists("MatrixPrintForm", envir=asNamespace("formatters")))
+      formatters::MatrixPrintForm
+    else if (exists("matrix_print_form", envir=asNamespace("formatters")))
+      formatters::matrix_print_form
+    else
+      stop("formatters::MatrixPrintForm does not exist")
+      
+  MatrixPrintForm(strings = strings,
                     spans = spans,
                     aligns = aligns,
                     formats = formats,


### PR DESCRIPTION
to `MatrixPrintForm`.