### PR TITLE
add fontspec for vert_pag_indices call in example

### DIFF
--- a/man/matrix_form.tabular.Rd
+++ b/man/matrix_form.tabular.Rd
@@ -56,7 +56,7 @@ if (requireNamespace("formatters")) {
   
   # This gives the breaks by columns, counting the
   # row label columns:
-  bycol <- formatters::vert_pag_indices(mform, cpp = 30,  rep_cols = 2)
+  bycol <- formatters::vert_pag_indices(mform, cpp = 30,  rep_cols = 2, fontspec = NULL)
   # Display the table with both kinds of breaks
   for (i in seq_along(byrow)) {
     rows <- byrow[[i]]


### PR DESCRIPTION
most things have a default fontspec value but I missed `vert_pag_indices` as its not usually called directly. Will be fixed in the next release (which won't be for a while because this one just landed on cran) but in the meantime this fixes your example tables passes check for me after the change.